### PR TITLE
Upgrade cortex-m dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,12 @@ readme = "quickstart.md"
 
 [dependencies]
 bare-metal = "0.1.1"
-cortex-m = "0.4.3"
+cortex-m = "0.6"
 vcell = "0.1.0"
 
 [dependencies.cortex-m-rt]
 optional = true
-version = "0.3.12"
+version = "0.6.11"
 
 [features]
 rt = ["cortex-m-rt"]
-
-


### PR DESCRIPTION
The cortex-m untagged-option dependency is failing to compile, latest cortex-m release has dropped this dependency.